### PR TITLE
Fix: Provide Application Default Credentials to test run.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /build/
 COPY pom.xml /build/
 COPY src /build/src/
 
-RUN mvn test
+RUN mvn test -DAPPLICATION_DEFAULT_CREDENTIALS=testing
 
 RUN mvn clean package -DskipTests
 


### PR DESCRIPTION
In non-Google environments, APPLICATION_DEFAULT_CREDENTIALS is undefined and this will cause a failure in testing.

This defines the variable while running tests in the Docker.